### PR TITLE
[FIx] Parametro na função de calculo do IRRF

### DIFF
--- a/l10n_br_hr_payroll/data/l10n_br_hr_payroll_rubricas.xml
+++ b/l10n_br_hr_payroll/data/l10n_br_hr_payroll_rubricas.xml
@@ -42,7 +42,7 @@
             <field name="category_id" ref="hr_payroll.IRPF"/>
             <field name="condition_select">none</field>
             <field name="amount_select">code</field>
-            <field name="amount_python_compute">result = CALCULAR.IRRF(BASE_IR, INSS)</field>
+            <field name="amount_python_compute">result = CALCULAR.IRRF(BASE_IRPF, INSS)</field>
             <field name="sequence" eval="502"/>
         </record>
 


### PR DESCRIPTION
O cálculo do IRRF utilizava o BASE_IRRF cheio, isso é, sem as deduções.. 
Agora utiliza o BASE_IR que ja contem as deduções BASE_IR = BASE_INSS - INSS - dedução_dependente