### PR TITLE
Fix/controle ferias

### DIFF
--- a/l10n_br_hr_gerador_holerite/README.rst
+++ b/l10n_br_hr_gerador_holerite/README.rst
@@ -58,10 +58,7 @@ Images
 Contributors
 ------------
 
-* Luis Felipe Miléo <mileo@kmee.com.br>
-* Matheus Felix
-* Rafael da Silva Lima
-* Aristides Caldeira <aristides.caldeira@tauga.com.br>
+* Hendrix Costa <hendrix.costa@kmee.com.br>
 
 Funders
 -------

--- a/l10n_br_hr_payroll/demo/hr_contract.xml
+++ b/l10n_br_hr_payroll/demo/hr_contract.xml
@@ -12,7 +12,7 @@
             <field eval="1.0" name="time_efficiency"/>
             <field name="company_id" ref="base.main_company"/>
             <field eval="1" name="active"/>
-            <field name="name">Tony Stark</field>
+            <field name="name">Antony Edward Stark</field>
             <field name="resource_type">user</field>
             <field name="work_phone">+24242424</field>
             <field name="image" type="base64"
@@ -47,7 +47,7 @@
             <field eval="1.0" name="time_efficiency"/>
             <field name="company_id" ref="base.main_company"/>
             <field eval="1" name="active"/>
-            <field name="name">Bruce Banner</field>
+            <field name="name">Robert Bruce Banner</field>
             <field name="resource_type">user</field>
             <field name="work_phone">+71717171</field>
             <field name="image" type="base64"

--- a/l10n_br_hr_payroll/tests/__init__.py
+++ b/l10n_br_hr_payroll/tests/__init__.py
@@ -4,3 +4,4 @@
 
 from . import test_hr_payslip
 from . import test_hr_payslip_rubricas
+from . import test_l10n_br_hr_contract

--- a/l10n_br_hr_payroll/tests/test_l10n_br_hr_contract.py
+++ b/l10n_br_hr_payroll/tests/test_l10n_br_hr_contract.py
@@ -41,8 +41,7 @@ class TestHrHoliday(common.TransactionCase):
             'l10n_br_hr_holiday.holiday_status_vacation')
 
         # Solicitacao de férias do funcionario
-        ferias = self.hr_holidays.\
-            create({
+        ferias = self.hr_holidays.create({
             'name': 'Ferias Do ' + contrato.employee_id.name,
             'type': 'remove',
             'parent_id': holiday_periodo_aquisitivo.id,

--- a/l10n_br_hr_payroll/tests/test_l10n_br_hr_contract.py
+++ b/l10n_br_hr_payroll/tests/test_l10n_br_hr_contract.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 KMEE INFORMATICA LTDA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import exceptions
+from openerp.tests import common
+# from openerp.exceptions import Warning as UserError
+
+
+class TestHrHoliday(common.TransactionCase):
+
+    def setUp(self):
+        super(TestHrHoliday, self).setUp()
+        # Usefull models
+        self.hr_employee = self.env['hr.employee']
+        self.hr_contract = self.env['hr.contract']
+        self.hr_holidays = self.env['hr.holidays']
+
+    def buscar_periodo_aquisitivo(self, contrato, inicio_ferias, fim_ferias):
+        for controle_ferias in contrato.vacation_control_ids:
+            if controle_ferias.inicio_concessivo < inicio_ferias and \
+               controle_ferias.fim_concessivo > fim_ferias:
+                if not controle_ferias.hr_holiday_ids:
+                    controle_ferias.gerar_holidays_ferias()
+                holidays = controle_ferias.hr_holiday_ids
+                for holiday in holidays:
+                    if holiday.type == 'add':
+                        return holiday
+
+    def atribuir_ferias(self, contrato, inicio_ferias,
+                        fim_ferias, dias_ferias, dias_abono):
+        """
+        Atribui férias ao funcionário.
+        Cria um holidays nos dias que o funcionario ira gozar as ferias .
+        """
+        # Buscar periodo Aquisitivo de acordo com os dias de ferias gozadas
+        holiday_periodo_aquisitivo = self.buscar_periodo_aquisitivo(
+            contrato, inicio_ferias, fim_ferias)
+
+        holiday_status_id = self.env.ref(
+            'l10n_br_hr_holiday.holiday_status_vacation')
+
+        # Solicitacao de férias do funcionario
+        ferias = self.hr_holidays.\
+            create({
+            'name': 'Ferias Do ' + contrato.employee_id.name,
+            'type': 'remove',
+            'parent_id': holiday_periodo_aquisitivo.id,
+            'holiday_type': 'employee',
+            'holiday_status_id': holiday_status_id.id,
+            'employee_id': contrato.employee_id.id,
+            'vacations_days': dias_ferias,
+            'sold_vacations_days': dias_abono,
+            'number_of_days_temp': dias_ferias + dias_abono,
+            'date_from': inicio_ferias,
+            'date_to': fim_ferias,
+            'contrato_id': contrato.id,
+        })
+        # Chamando Onchange manualmente para setar o controle de férias
+        ferias._compute_contract()
+        # Aprovacao da solicitacao do funcionario
+        ferias.holidays_validate()
+
+    def criar_contrato(self, date_start):
+        """
+        Criar um novo contrato para o funcionario
+        :param name:        str - Nome Referencia do contrato
+        :param wage:
+        :param struct_id:
+        :param date_start:
+        :return:
+        """
+        employee_id = self.criar_funcionario('ANA BEATRIZ CARVALHO')
+        estrutura_salario = self.env.ref(
+            'l10n_br_hr_payroll.hr_salary_structure_FUNCAO_COMISSIONADA')
+        contrato_id = self.hr_contract.create({
+            'name': 'Contrato ' + employee_id.name,
+            'employee_id': employee_id.id,
+            'wage': 12345.67,
+            'struct_id': estrutura_salario.id,
+            'date_start': date_start,
+        })
+        return contrato_id
+
+    def criar_funcionario(self, nome):
+        """
+        Criar um employee apartir de um nome e sua quantidade de dependentes
+        :param nome: str Nome do funcionario
+        :return: hr.employee
+        """
+        funcionario = self.hr_employee.create({'name': nome})
+        return funcionario
+
+    def test_00_criacao_contrato(self):
+        """
+        Criacao de um contrato simples
+        """
+        contrato = self.criar_contrato('2014-01-01')
+
+        self.assertEqual(contrato.employee_id.name, 'ANA BEATRIZ CARVALHO')
+        self.assertEqual(contrato.name, 'Contrato ANA BEATRIZ CARVALHO')
+        self.assertEqual(contrato.date_start, '2014-01-01')
+        self.assertEqual(contrato.wage, 12345.67)
+
+    def test_01_verificar_controle_ferias(self):
+        """
+        Verificar a criação do controle de férias
+        :return:
+        """
+        # Criar Contrato
+        contrato = self.criar_contrato('2014-01-01')
+
+        # Verificar a criação do controle de férias
+        controle = contrato.vacation_control_ids[0]
+        self.assertEqual(len(contrato.vacation_control_ids), 4)
+        self.assertEqual(controle.inicio_aquisitivo, '2014-01-01')
+        self.assertEqual(controle.fim_aquisitivo, '2014-12-31')
+        self.assertEqual(controle.inicio_concessivo, '2015-01-01')
+        self.assertEqual(controle.fim_concessivo, '2015-12-31')
+
+        # Verificar a criação dos holidays que atribuem férias ao funcionario
+        # A Criação só é feita automatica para os dois ultimos controlesferias
+        for controle in contrato.vacation_control_ids[-2:]:
+            self.assertEqual(len(controle.hr_holiday_ids), 1)
+            self.assertEqual(controle.hr_holiday_ids.number_of_days_temp, 30)
+            self.assertEqual(controle.hr_holiday_ids.type, 'add')
+
+    def test_02_editar_contrato(self):
+        """
+        Para editar a data de admissao no contrato , nao se pode ter nenhum
+        holiday aprovado de férias do tipo remove, atrelado ao contrato.
+        """
+        # Criar Contrato
+        contrato = self.criar_contrato('2014-01-01')
+
+        # Edição do contrato
+        contrato.date_start = '2010-08-01'
+
+        controle = contrato.vacation_control_ids[0]
+        self.assertEqual(len(contrato.vacation_control_ids), 7)
+        self.assertEqual(controle.inicio_aquisitivo, '2010-08-01')
+        self.assertEqual(controle.fim_aquisitivo, '2011-07-31')
+        self.assertEqual(controle.inicio_concessivo, '2011-08-01')
+        self.assertEqual(controle.fim_concessivo, '2012-07-31')
+
+        # verificar a criação de novos holidays de férias
+        for controle in contrato.vacation_control_ids[-2:]:
+            self.assertEqual(len(controle.hr_holiday_ids), 1)
+            self.assertEqual(controle.hr_holiday_ids.number_of_days_temp, 30)
+            self.assertEqual(controle.hr_holiday_ids.type, 'add')
+
+    def test_03_gerar_novo_controle_ferias(self):
+        """
+        Se apagar algum controle ou por algum motivo o usuario deseja acionar
+        o botão da visão e recalcular o controle de ferias
+        """
+        # Criar Contrato
+        contrato = self.criar_contrato('2014-01-01')
+
+        # Excluir controles
+        for controle in contrato.vacation_control_ids:
+            controle.unlink()
+
+        # teste da exclusao do controle
+        self.assertEqual(len(contrato.vacation_control_ids), 0)
+
+        # verificar a exclusão dos holidays antigos de férias
+        holiday_status_id = self.env.ref(
+            'l10n_br_hr_holiday.holiday_status_vacation')
+        for holiday in contrato.afastamento_ids:
+            self.assertNotEqual(holiday.holiday_status_id.id,
+                                holiday_status_id.id)
+
+        # Método disparado pelo botão da visão
+        contrato.action_button_update_controle_ferias()
+        # Validar criação de novos controles de fériass
+        self.assertEqual(len(contrato.vacation_control_ids), 4)
+        # Validar a criação do holiday do controle de férias novamente
+        for controle in contrato.vacation_control_ids[-2:]:
+            self.assertEqual(len(controle.hr_holiday_ids), 1)
+
+    def test_04_editar_contrato_com_ferias(self):
+        """
+        Não é possível editar um contrato que ja possui férias (holidays do
+        tipo 'remove') atrelado a ele,
+        """
+        # Criar Contrato
+        contrato = self.criar_contrato('2014-01-01')
+
+        # Atribuir holidays de solicitação de ferias aprovado
+        self.atribuir_ferias(contrato, '2016-10-01', '2016-10-30', 30, 0)
+        # Verificar se tem holidays de solicitação de férias aprovado para o
+        # contrato corrente
+        holiday_status_id = self.env.ref(
+            'l10n_br_hr_holiday.holiday_status_vacation')
+        ferias_atribuida = False
+        for holidays in contrato.afastamento_ids:
+            if holidays.holiday_status_id.id == holiday_status_id.id and \
+               holidays.type == 'remove':
+                ferias_atribuida = True
+        self.assertTrue(ferias_atribuida)
+
+        # Se ja tiver holidays, nao permite alteração da data do contrato
+        with self.assertRaises(exceptions.Warning):
+            contrato.date_start = '2015-02-02'

--- a/l10n_br_hr_payroll/views/hr_contract.xml
+++ b/l10n_br_hr_payroll/views/hr_contract.xml
@@ -144,13 +144,13 @@
                     </field>
                 </page>
                 <!--Aba Afastamentos-->
-                <page string="Afastamentos">
+                <page string="Ocorrências e Férias">
                     <field name="afastamento_ids">
                         <tree>
-                            <field name="contrato_id" string="Contrato"/>
-                            <field name="rubrica"/>
-                            <field name="periodo"/>
-                            <field name="valor_inss"/>
+                            <field name="holiday_status_id"/>
+                            <field name="data_inicio"/>
+                            <field name="data_fim"/>
+                            <field name="state"/>
                         </tree>
                     </field>
                 </page>

--- a/l10n_br_hr_payroll/views/hr_payslip.xml
+++ b/l10n_br_hr_payroll/views/hr_payslip.xml
@@ -35,7 +35,6 @@
             <field name="search_view_id" ref="hr_payroll.view_hr_payslip_filter"/>
             <field name="context">{'default_tipo_de_folha': 'normal'}</field>
             <field name="domain">[('tipo_de_folha','=','normal')]</field>
-            <field name="priority" eval="105"/>
         </record>
 
         <record model="ir.ui.view" id="hr_payslip_form_view">

--- a/l10n_br_hr_vacation/models/hr_contract.py
+++ b/l10n_br_hr_vacation/models/hr_contract.py
@@ -77,7 +77,7 @@ class HrContract(models.Model):
         vacation_id = self.env.ref(
             'l10n_br_hr_holiday.holiday_status_vacation').id
 
-        holidays_ferias_do_contrato =  self.env['hr.holidays'].search([
+        holidays_ferias_do_contrato = self.env['hr.holidays'].search([
             ('type', '=', 'remove'),
             ('contrato_id', '=', self.id),
             ('holiday_status_id', '=', vacation_id),

--- a/l10n_br_hr_vacation/models/hr_vacation_control.py
+++ b/l10n_br_hr_vacation/models/hr_vacation_control.py
@@ -2,9 +2,10 @@
 # Copyright 2016 KMEE - Hendrix Costa <hendrix.costa@kmee.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from openerp import api, models, fields
-from dateutil.relativedelta import relativedelta
 from datetime import datetime
+
+from dateutil.relativedelta import relativedelta
+from openerp import api, models, fields
 
 
 class HrVacationControl(models.Model):
@@ -116,7 +117,7 @@ class HrVacationControl(models.Model):
         relation='vacation_control_holidays_rel',
         column1='hr_vacation_control_id',
         column2='holiday_id',
-        string='Período Aquisitivo'
+        string=u'Período Aquisitivo',
     )
 
     display_name = fields.Char(

--- a/l10n_br_hr_vacation/models/hr_vacation_control.py
+++ b/l10n_br_hr_vacation/models/hr_vacation_control.py
@@ -266,3 +266,13 @@ class HrVacationControl(models.Model):
         """
         for controle in self:
             controle.gerar_holidays_ferias()
+
+    @api.multi
+    def unlink(self):
+        """
+        Se excluir o controle de ferias, excluir todos os holidays atrelados
+        FIXTO: utilizar o ondelete=cascade na definição do campo
+        """
+        for holidays in self.hr_holiday_ids:
+            holidays.unlink()
+        return super(HrVacationControl, self).unlink()

--- a/l10n_br_hr_vacation/views/hr_vacation_control_view.xml
+++ b/l10n_br_hr_vacation/views/hr_vacation_control_view.xml
@@ -40,7 +40,7 @@
                                 />
                             </tree>
                         </field>
-                        <button name="atualizar_controle_ferias"
+                        <button name="action_button_update_controle_ferias"
                                 string="Gerar período aquisitivo"
                                 type="object" class="oe_highlight"/>
                     </page>


### PR DESCRIPTION
Quando criar um contrato, as linhas do controle de férias são geradas automaticamente. 
 - Atualizar o controle de férias através do botão "Gerar período aquisitivo".
  Quando excluir alguma linha manualmente e clicar no botão  "Gerar período aquisitivo", o sistema excluirá todas as linhas e criará novamente.

- Validar a edição da data de contratação do contrato
  Se o contrato já possuir algum holiday (férias ou ocorrências) atribuído á ele, não permite a edição da data de admissão no contrato.

Recursos Humanos > Contratos > Criar 

![captura de tela de 2017-05-10 08 30 47](https://cloud.githubusercontent.com/assets/7250580/25896572/1a7f9714-355b-11e7-93ca-b93e87c4ffa0.png)



