### PR TITLE
[Fix] Permitir mudar a data de inicio da importação dos feriados

### DIFF
--- a/l10n_br_resource/wizard/workalendar_holiday_import.py
+++ b/l10n_br_resource/wizard/workalendar_holiday_import.py
@@ -52,7 +52,7 @@ class WorkalendarHolidayImport(models.TransientModel):
         ('months', 'Month(s)'),
         ('years', 'Year(s)')],
         string='Type',
-        default='days',
+        default='years',
         required=True
     )
     calendar_id = fields.Many2one(

--- a/l10n_br_resource/wizard/workalendar_holiday_import.xml
+++ b/l10n_br_resource/wizard/workalendar_holiday_import.xml
@@ -8,12 +8,10 @@
             <field name="arch" type="xml">
                 <form string="Import Brazilian Holidays">
                     <div class="oe_title">
-                        <h1>
-                            <label string="Import Public Holidays from"/>
-                            <field name="start_date" class="oe_inline" readonly="1"/>
-                            <label string="until"/>
-                            <field name="end_date" class="oe_inline" readonly="1"/>
-                        </h1>
+                        <label string="Import Public Holidays from"/>
+                        <field name="start_date" class="oe_inline" readonly="0"/>
+                        <label string="until"/>
+                        <field name="end_date" class="oe_inline" readonly="1"/>
                     </div>
                     <group>
                         <group string="Interval">


### PR DESCRIPTION
US# 457
Permite alterar a data de inicio da importação dos feriados
Define padrão de importação para Anos ao invés de Dias.