### PR TITLE
[FIX] Substituir regra de acesso ao holerite

### DIFF
--- a/l10n_br_hr_payroll/security/l10n_br_hr_payslip_security_rule.xml
+++ b/l10n_br_hr_payroll/security/l10n_br_hr_payslip_security_rule.xml
@@ -7,8 +7,8 @@
     <!-- Deletar regra com "no-update True"-->
     <delete id="hr_payroll.property_rule_employee_payslip" model="ir.rule"/>
 
-    <record id="property_rule_employee_payslip_employee" model="ir.rule">
-        <field name="name">Employee Payslip test</field>
+    <record id="hr_payroll.property_rule_employee_payslip" model="ir.rule">
+        <field name="name">Employee Payslip</field>
         <field name="model_id" ref="model_hr_payslip"/>
         <field name="domain_force">['|', ('employee_id.user_id', '=', user.id), ('employee_id.department_id.manager_id.user_id', '=', user.id)]</field>
         <field name="groups" eval="[(4,ref('base.group_user'))]"/>


### PR DESCRIPTION
Comportamento anterior: 
1 - A regra deveria ser excluída, pois no core tem a instrução noupdate, o que impossibilidata alterações.
2 - Com a regra excluída, era criado outra regra com as alterações necessárias
Problema:  Como a instrução de excluir a regra fica no módulo, a cada atualização do módulo, era processada a instrução de exclusão. Como já foi excluída, na atualização a instrução não encontrava a regra para excluir novamente.

Comportamento esperado:
1- Recriar a regra com o mesmo nome anterior.
Solução: Como a regra criada tem o mesmo nome, a cada atualização do módulo a regra será excluida e criada novamente.