### PR TITLE
[FIX] Exclusão das rubricas especificas quando excluir o contrato

### DIFF
--- a/l10n_br_hr_payroll/models/hr_contract.py
+++ b/l10n_br_hr_payroll/models/hr_contract.py
@@ -105,6 +105,7 @@ class HrContract(models.Model):
         comodel_name='hr.contract.salary.rule',
         inverse_name='contract_id',
         string=u"Rúbricas específicas",
+        ondelete='cascade',
     )
     change_salary_ids = fields.One2many(
         comodel_name='l10n_br_hr.contract.change',

--- a/l10n_br_hr_payroll/models/hr_payslip.py
+++ b/l10n_br_hr_payroll/models/hr_payslip.py
@@ -406,7 +406,7 @@ class HrPayslip(models.Model):
         compute='_compute_valor_total_folha',
     )
     fim_gozo_fmt = fields.Char(
-        string=u'Fom do Período de Gozo Formatado',
+        string=u'Fim do Periodo de Gozo Formatado',
         compute='_compute_valor_total_folha',
     )
 


### PR DESCRIPTION
Comportamento anterior:
Na exclusão do contrato as rubricas especificas não eram excluídas, perdendo a rastreabilidade já que o unico lugar que eh exibido o modelo é na view do contrato. 

Comportamento esperado:
Excluir o contrato, deve-se excluir também as rubricas especificas.