### PR TITLE
[WIP] Revisão dos Menus de Recursos Humanos

### DIFF
--- a/l10n_br_hr_payroll/views/l10n_br_hr_contract.xml
+++ b/l10n_br_hr_payroll/views/l10n_br_hr_contract.xml
@@ -9,7 +9,7 @@
             <field name="name">Alterações contratuais</field>
             <field name="parent_id" ref="hr.menu_hr_main"/>
             <field name="sequence" eval="5"/>
-            <field eval="[(4, ref('base.group_hr_manager'))]" name="groups_id"/>
+            <field eval="[(4, ref('base.group_hr_user'))]" name="groups_id"/>
         </record>
 
     </data>

--- a/l10n_br_hr_payroll/views/l10n_br_hr_contract_cargo_atividade.xml
+++ b/l10n_br_hr_payroll/views/l10n_br_hr_contract_cargo_atividade.xml
@@ -82,10 +82,11 @@
     </record>
 
     <record model="ir.actions.act_window.view" id="l10n_br_hr_contract_change_cargo_atividade_form_action">
-        <field eval="2" name="sequence"/>
+        <field eval="3" name="sequence"/>
         <field name="view_mode">form</field>
         <field name="act_window_id" ref="l10n_br_hr_contract_change_cargo_atividade_action"/>
         <field name="view_id" ref="l10n_br_hr_contract_change_cargo_atividade_form"/>
+        <field eval="[(4, ref('base.group_hr_user'))]" name="groups_id"/>
     </record>
 
 </data>

--- a/l10n_br_hr_payroll/views/l10n_br_hr_contract_filiacao_sindical.xml
+++ b/l10n_br_hr_payroll/views/l10n_br_hr_contract_filiacao_sindical.xml
@@ -83,10 +83,11 @@
         <field name="view_id" ref="l10n_br_hr_contract_change_filiacao_sindical_tree"/>
     </record>
     <record model="ir.actions.act_window.view" id="l10n_br_hr_contract_change_filiacao_sindical_form_action">
-        <field eval="2" name="sequence"/>
+        <field eval="4" name="sequence"/>
         <field name="view_mode">form</field>
         <field name="act_window_id" ref="l10n_br_hr_contract_change_filiacao_sindical_action"/>
         <field name="view_id" ref="l10n_br_hr_contract_change_filiacao_sindical_form"/>
+        <field eval="[(4, ref('base.group_hr_user'))]" name="groups_id"/>
     </record>
 
 </data>

--- a/l10n_br_hr_payroll/views/l10n_br_hr_contract_jornada.xml
+++ b/l10n_br_hr_payroll/views/l10n_br_hr_contract_jornada.xml
@@ -84,6 +84,7 @@
         <field name="view_mode">form</field>
         <field name="act_window_id" ref="l10n_br_hr_contract_change_jornada_action"/>
         <field name="view_id" ref="l10n_br_hr_contract_change_jornada_form"/>
+        <field eval="[(4, ref('base.group_hr_user'))]" name="groups_id"/>
     </record>
 
 </data>

--- a/l10n_br_hr_payroll/views/l10n_br_hr_contract_lotacao_local.xml
+++ b/l10n_br_hr_payroll/views/l10n_br_hr_contract_lotacao_local.xml
@@ -61,6 +61,7 @@
         <field name="parent_id" ref="hr_contract_change_menu"/>
         <field name="action" ref="l10n_br_hr_contract_change_lotacao_local_action"/>
         <field name="sequence" eval="5"/>
+        <field eval="[(4, ref('base.group_hr_user'))]" name="groups_id"/>
     </record>
 
 </data>

--- a/l10n_br_hr_payroll/views/l10n_br_hr_contract_remuneracao.xml
+++ b/l10n_br_hr_payroll/views/l10n_br_hr_contract_remuneracao.xml
@@ -78,6 +78,7 @@
         <field name="parent_id" ref="hr_contract_change_menu"/>
         <field name="action" ref="l10n_br_hr_contract_change_remuneracao_action"/>
         <field name="sequence" eval="1"/>
+        <field eval="[(4, ref('base.group_hr_user'))]" name="groups_id"/>
     </record>
 
 </data>

--- a/l10n_br_hr_payroll_account/views/l10n_br_hr_payroll_account_view.xml
+++ b/l10n_br_hr_payroll_account/views/l10n_br_hr_payroll_account_view.xml
@@ -31,46 +31,46 @@
                 <field name="arch" type="xml">
                 <xpath expr="/form/notebook/page[@string='Child Rules']" position="after">
                     <page string="Accounting">
-                        <separator string="Contas Provisão Férias"/>
-                        <group>
-                            <group>
-                                <field name="provisao_ferias_account_debit"/>
-                                <field name="provisao_ferias_account_credit"/>
-                            </group>
-                        </group>
-                        <separator string="Contas Provisão Décimo Terceiro"/>
-                        <group>
-                            <group>
-                                <field name="provisao_13_account_debit"/>
-                                <field name="provisao_13_account_credit"/>
-                            </group>
-                        </group>
-                        <separator string="Contas Holerite Normal"/>
+                        <separator string="Contas Contábeis para Cálculo de Folha Normal"/>
                         <group>
                             <group>
                                 <field name="holerite_normal_account_debit"/>
                                 <field name="holerite_normal_account_credit"/>
                             </group>
                         </group>
-                        <separator string="Contas Férias"/>
+                        <separator string="Contas Contábeis para Cálculo de Férias"/>
                         <group>
                             <group>
                                 <field name="ferias_account_debit"/>
                                 <field name="ferias_account_credit"/>
                             </group>
                         </group>
-                        <separator string="Contas Décimo 13º"/>
+                        <separator string="Contas Contábeis para Cálculo de 13º (Segunda Parcela)"/>
                         <group>
                             <group>
                                 <field name="decimo_13_account_debit"/>
                                 <field name="decimo_13_account_credit"/>
                             </group>
                         </group>
-                        <separator string="Contas Rescisão"/>
+                        <separator string="Contas Contábeis para Cálculo de Rescisão"/>
                         <group>
                             <group>
                                 <field name="rescisao_account_debit"/>
                                 <field name="rescisao_account_credit"/>
+                            </group>
+                        </group>
+                        <separator string="Contas Contábeis para Cálculo de Provisão de Férias"/>
+                        <group>
+                            <group>
+                                <field name="provisao_ferias_account_debit"/>
+                                <field name="provisao_ferias_account_credit"/>
+                            </group>
+                        </group>
+                        <separator string="Contas Contábeis para Cálculo de Provisão de 13º"/>
+                        <group>
+                            <group>
+                                <field name="provisao_13_account_debit"/>
+                                <field name="provisao_13_account_credit"/>
                             </group>
                         </group>
                     </page>


### PR DESCRIPTION
Para Melhorar a utilização da Folha de Pagamento, precisamos revisar as opções de menus de Recursos Humanos, ajustando a ordem das opções, mudando os grupos de permissões para evitar alguns usuários específicos de acessarem o que não podem e esconder as opções desnecessárias no momento.