### PR TITLE
[Fix] Mudar método _verificar_ferias_vencidas para api.one

### DIFF
--- a/l10n_br_hr_payroll/models/hr_payslip.py
+++ b/l10n_br_hr_payroll/models/hr_payslip.py
@@ -856,7 +856,7 @@ class HrPayslip(models.Model):
             return estrutura_provisao_decimo_terceiro
 
     @api.depends('contract_id', 'date_from', 'date_to')
-    @api.multi
+    @api.one
     def _verificar_ferias_vencidas(self):
         periodo_ferias_vencida = self.env['hr.vacation.control'].search(
             [


### PR DESCRIPTION
Mudado para api.on o método _verificar_ferias_vencidas para evitar erro "Expected Singleton" enquanto gera o relatório analítico.