### PR TITLE
[FIX] Removido required to campo identity_city_id

### DIFF
--- a/l10n_br_hr_arquivos_governo/views/l10n_br_hr_employee.xml
+++ b/l10n_br_hr_arquivos_governo/views/l10n_br_hr_employee.xml
@@ -79,10 +79,6 @@
                     <attribute name="required">1</attribute>
                 </field>
 
-                <field name="identity_city_id" position="attributes">
-                    <attribute name="required">1</attribute>
-                </field>
-
             </field>
         </record>
 

--- a/l10n_br_hr_arquivos_governo/views/l10n_br_hr_employee.xml
+++ b/l10n_br_hr_arquivos_governo/views/l10n_br_hr_employee.xml
@@ -55,10 +55,6 @@
                     <attribute name="required">1</attribute>
                 </field>
 
-                <field name="identity_type_id" position="attributes">
-                    <attribute name="required">1</attribute>
-                </field>
-
                 <field name="rg" position="attributes">
                     <attribute name="required">1</attribute>
                 </field>
@@ -68,10 +64,6 @@
                 </field>
 
                 <field name="rg_emission" position="attributes">
-                    <attribute name="required">1</attribute>
-                </field>
-
-                <field name="identity_validity" position="attributes">
                     <attribute name="required">1</attribute>
                 </field>
 


### PR DESCRIPTION
O campo Cidade da Emissão da Identidade não deve ser required, retirado da view.