### PR TITLE
[FIX] mês do holerite de férias de acordo com a data das férias

### DIFF
--- a/l10n_br_hr_payroll/models/hr_payslip.py
+++ b/l10n_br_hr_payroll/models/hr_payslip.py
@@ -2159,8 +2159,9 @@ class HrPayslip(models.Model):
                 record.mes_do_ano = datetime.now().months
                 record.mes_do_ano2 = datetime.now().month
             if record.tipo_de_folha == 'ferias' and record.holidays_ferias:
-                record.periodo_aquisitivo =\
-                    record.holidays_ferias.parent_id.controle_ferias_ids[0]
+                if record.holidays_ferias.parent_id.controle_ferias_ids:
+                    record.periodo_aquisitivo =\
+                        record.holidays_ferias.parent_id.controle_ferias_ids[0]
                 record.date_from = record.holidays_ferias.data_inicio
                 record.date_to = record.holidays_ferias.data_fim
                 record.mes_do_ano = \


### PR DESCRIPTION
estava sendo mostrada a data do processamento e não das férias, para isso foi corrigido o erro de "IndexError: list index out of range" que permitiu que o 'mes_do_ano' fosse setado corretamente