### PR TITLE
[FIX] Ocultar contratos quando os holerites forem gerados em adiantamento de 13º

### DIFF
--- a/l10n_br_hr_payroll/models/hr_payslip_run.py
+++ b/l10n_br_hr_payroll/models/hr_payslip_run.py
@@ -159,6 +159,12 @@ class HrPayslipRun(models.Model):
             # Buscar contratos validos
             contracts_id = self.env['hr.contract'].search(dominio_contratos)
 
+            # Caso o tipo de lote for "Adiantamento de 13º", deverá ser trocado
+            # por "decimo_terceiro", já que os holerites são criados com esse
+            # tipo
+            if self.tipo_de_folha == 'adiantamento_13':
+                self.tipo_de_folha = 'decimo_terceiro'
+
             # buscar payslip ja processadas dos contratos validos
             dominio_payslips = [
                 ('tipo_de_folha', '=', self.tipo_de_folha),


### PR DESCRIPTION
No lote de "Adiantamento de 13º" os contratos não sumiam após gerar os holerites, causando duplicidade se gerasse os holerites novamente.

O problema era causado devido à diferença entre os tipos de folhas entre Lote e Holerite.