### PR TITLE
Correções BASE_FGTS_13

### DIFF
--- a/l10n_br_hr_payroll/models/hr_payslip.py
+++ b/l10n_br_hr_payroll/models/hr_payslip.py
@@ -163,8 +163,8 @@ class HrPayslip(models.Model):
                 total += line.valor_provento - line.valor_deducao
                 total_proventos += line.valor_provento
                 total_descontos += line.valor_deducao
-                if line.code == 'BASE_FGTS':
-                    base_fgts = line.total
+                if line.code in ['BASE_FGTS', 'BASE_FGTS_13']:
+                    base_fgts += line.total
                 elif line.code == 'BASE_INSS':
                     base_inss = line.total
                 elif line.code == 'BASE_IRPF':

--- a/l10n_br_hr_payroll_report/reports/payslip_report_analitico.py
+++ b/l10n_br_hr_payroll_report/reports/payslip_report_analitico.py
@@ -241,11 +241,7 @@ def analytic_report(pool, cr, uid, local_context, context):
             total_descontos += rubrica['sum']
             if rubrica['category'] == 'INSS':
                 inss_funcionario_retido += rubrica['sum']
-        if wizard.tipo_de_folha == "('decimo_terceiro')":
-            if rubrica['code'] == 'BASE_FGTS_13':
-                base_fgts = rubrica['sum']
-        else:
-            if rubrica['code'] == 'BASE_FGTS':
+        if rubrica['code'] in ['BASE_FGTS', 'BASE_FGTS_13']:
                 base_fgts = rubrica['sum']
 #        if rubrica['code'] == 'FGTS':
 #            fgts = rubrica['sum']

--- a/l10n_br_hr_payroll_report/reports/payslip_report_analitico.py
+++ b/l10n_br_hr_payroll_report/reports/payslip_report_analitico.py
@@ -242,7 +242,7 @@ def analytic_report(pool, cr, uid, local_context, context):
             if rubrica['category'] == 'INSS':
                 inss_funcionario_retido += rubrica['sum']
         if rubrica['code'] in ['BASE_FGTS', 'BASE_FGTS_13']:
-                base_fgts = rubrica['sum']
+                base_fgts += rubrica['sum']
 #        if rubrica['code'] == 'FGTS':
 #            fgts = rubrica['sum']
 


### PR DESCRIPTION
[FIX] Adicionar a base do FGTS de 13º à soma da base que aparece em cada holerite:

> No relatório analítico do 13º em cada funcionário não era exibido a Base de FGTS corretamente pois a rubrica BASE_FGTS_13 não constava no código para a soma no campo "base_fgts_fmt" do holerite.

[FIX] Mudança no entendimento na condição da soma da base de fgts:

> Mudança de entendimento na condição que identifica se era tipo de folha = decimo_terceiro, o que não é necessário pois um holerite não haverá BASE_FGTS e BASE_FGTS_13 ao mesmo tempo, então a condição pode ser utilizando o operator "IN", assim o código fica mais limpo.