### PR TITLE
[FIX] Verificar a data de nascimento do dependente para calcular o IRPF

### DIFF
--- a/l10n_br_hr_payroll/models/hr_payslip.py
+++ b/l10n_br_hr_payroll/models/hr_payslip.py
@@ -861,7 +861,7 @@ class HrPayslip(models.Model):
         dependent_values = 0
         for dependente in self.employee_id.dependent_ids:
             if dependente.dependent_verification and \
-                    dependente.dependent_dob<self.date_from:
+                    dependente.dependent_dob < self.date_from:
                 dependent_values += deducao_dependente_value.amount
 
         return TOTAL_IRRF - INSS - dependent_values

--- a/l10n_br_hr_payroll/models/hr_payslip.py
+++ b/l10n_br_hr_payroll/models/hr_payslip.py
@@ -860,7 +860,8 @@ class HrPayslip(models.Model):
         )
         dependent_values = 0
         for dependente in self.employee_id.dependent_ids:
-            if dependente.dependent_verification:
+            if dependente.dependent_verification and \
+                    dependente.dependent_dob<self.date_from:
                 dependent_values += deducao_dependente_value.amount
 
         return TOTAL_IRRF - INSS - dependent_values


### PR DESCRIPTION
O sistema não estava considerando a data de nascimento dos dependentes, gerando diferenças no IRPF em cálculos de lotes retroativos.