### PR TITLE
[FIX] Considerar também os lançamentos de INSS de 13º salário na soma…

### DIFF
--- a/l10n_br_hr_arquivos_governo/models/l10n_br_hr_sefip.py
+++ b/l10n_br_hr_arquivos_governo/models/l10n_br_hr_sefip.py
@@ -854,7 +854,7 @@ class L10nBrSefip(models.Model):
                                 'qtd_contribuintes'] = 1
                             contribuicao_sindical[id_sindicato][
                                 'total_remuneracao'] = remuneracao.total
-                    elif line.code == 'INSS':
+                    elif line.code in ['INSS', 'INSS_13']:
                         empresas[line.slip_id.company_id.id][
                             'INSS_funcionarios'] += line.total
                     elif line.code == 'INSS_EMPRESA':


### PR DESCRIPTION
Nos lançamentos financeiros, o código não estava considerando a rubrica INSS de origem do 13º salário. Causando diferença no lançamento financeiro da GPS.