### PR TITLE
[FIX] Considerar também os lançamentos de IRPF de 13º salário na soma…

### DIFF
--- a/l10n_br_hr_arquivos_governo/models/l10n_br_hr_sefip.py
+++ b/l10n_br_hr_arquivos_governo/models/l10n_br_hr_sefip.py
@@ -866,7 +866,7 @@ class L10nBrSefip(models.Model):
                     elif line.code == 'INSS_RAT_FAP':
                         empresas[line.slip_id.company_id.id][
                             'INSS_rat_fap'] += line.total
-                    elif line.code == 'IRPF':
+                    elif line.code in ['IRPF', 'IRPF_13']:
                         if line.slip_id.contract_id.categoria in \
                                 ['721', '722']:
                             codigo_darf = '0588'


### PR DESCRIPTION
Nos lançamentos financeiros, o código não estava considerando a rubrica IRPF de origem do 13º salário. Causando diferença no lançamento financeiro do DARF.