### PR TITLE
[FIX] Correção na geração das guias em PDF

### DIFF
--- a/l10n_br_hr_arquivos_governo/models/l10n_br_hr_sefip.py
+++ b/l10n_br_hr_arquivos_governo/models/l10n_br_hr_sefip.py
@@ -12,13 +12,13 @@ import tempfile
 import logging
 import base64
 import pybrasil
-import sh
 from py3o.template import Template
 from datetime import timedelta
 from openerp import api, fields, models, _
 from openerp.exceptions import ValidationError
 from pybrasil.valor import formata_valor
 from pybrasil.data import formata_data
+import subprocess
 
 from openerp.addons.l10n_br_base.tools.misc import punctuation_rm
 
@@ -630,7 +630,7 @@ class L10nBrSefip(models.Model):
 
         dir_base = os.path.dirname(os.path.dirname(os.path.dirname(CURDIR)))
         arquivo_template_darf = os.path.join(dir_base,
-                                            'kmee_odoo_addons',
+                                            'odoo-brazil-hr',
                                             'l10n_br_hr_payroll_report',
                                             'data',
                                             'darf.odt'
@@ -659,8 +659,11 @@ class L10nBrSefip(models.Model):
 
             template = Template(template_darf, arquivo_temporario.name)
             template.render(vals_impressao)
-            sh.libreoffice('--headless', '--invisible', '--convert-to', 'pdf',
-                           '--outdir', '/tmp', arquivo_temporario.name)
+
+            p = subprocess.Popen(['libreoffice', '--headless', '--invisible',
+                                  '--convert-to', 'pdf', '--outdir', '/tmp',
+                                  arquivo_temporario.name])
+            p.wait()
 
             pdf = open(arquivo_temporario.name + '.pdf', 'rb').read()
 
@@ -728,7 +731,7 @@ class L10nBrSefip(models.Model):
 
         dir_base = os.path.dirname(os.path.dirname(os.path.dirname(CURDIR)))
         arquivo_template_gps = os.path.join(dir_base,
-                                            'kmee_odoo_addons',
+                                            'odoo-brazil-hr',
                                             'l10n_br_hr_payroll_report',
                                             'data',
                                             'gps.odt'
@@ -761,8 +764,11 @@ class L10nBrSefip(models.Model):
 
             template = Template(template_gps, arquivo_temporario.name)
             template.render(vals_impressao)
-            sh.libreoffice('--headless', '--invisible', '--convert-to', 'pdf',
-                           '--outdir', '/tmp', arquivo_temporario.name)
+
+            p = subprocess.Popen(['libreoffice', '--headless', '--invisible',
+                                '--convert-to', 'pdf', '--outdir', '/tmp',
+                                arquivo_temporario.name])
+            p.wait()
 
             pdf = open(arquivo_temporario.name + '.pdf', 'rb').read()
 

--- a/l10n_br_hr_arquivos_governo/models/l10n_br_hr_sefip.py
+++ b/l10n_br_hr_arquivos_governo/models/l10n_br_hr_sefip.py
@@ -866,7 +866,7 @@ class L10nBrSefip(models.Model):
                     elif line.code == 'INSS_RAT_FAP':
                         empresas[line.slip_id.company_id.id][
                             'INSS_rat_fap'] += line.total
-                    elif line.code == 'IRPF':
+                    elif line.code in ['IRPF', 'IRPF_13']:
                         if line.slip_id.contract_id.categoria in \
                                 ['721', '722']:
                             codigo_darf = '0588'


### PR DESCRIPTION
A geração das guias em GPS e DARF estavam buscando o template do lugar errado.

Além disso, no momento em que a conversão para PDF é realizada é preciso que o Odoo espere a finalização para que o arquivo seja aberto, por isso foi necessário trocar a biblioteca SH pela Subproccess que controla o processo.