### PR TITLE
[FIX] Incluir a rubrica IRPF_FERIAS nos lançamentos da SEFIP

### DIFF
--- a/l10n_br_hr_arquivos_governo/models/l10n_br_hr_sefip.py
+++ b/l10n_br_hr_arquivos_governo/models/l10n_br_hr_sefip.py
@@ -872,7 +872,7 @@ class L10nBrSefip(models.Model):
                     elif line.code == 'INSS_RAT_FAP':
                         empresas[line.slip_id.company_id.id][
                             'INSS_rat_fap'] += line.total
-                    elif line.code in ['IRPF', 'IRPF_13']:
+                    elif line.code in ['IRPF', 'IRPF_13', 'IRPF_FERIAS']:
                         if line.slip_id.contract_id.categoria in \
                                 ['721', '722']:
                             codigo_darf = '0588'


### PR DESCRIPTION
A rubrica IRPF foi dividida em Mensal e Férias, por isso é preciso que nos lançamentos financeiros seja considerada a rubrica IRPF_FERIAS para que o DARF dê certo.