### PR TITLE
[FIX] Correção no cálculo de avos do 13

### DIFF
--- a/l10n_br_hr_payroll/models/hr_payslip.py
+++ b/l10n_br_hr_payroll/models/hr_payslip.py
@@ -1791,7 +1791,7 @@ class HrPayslip(models.Model):
                 fields.Date.from_string(payslip.contract_id.date_start).day
             mes_inicio_contrato = \
                 fields.Date.from_string(payslip.contract_id.date_start).month
-            avos_13 = int(payslip.mes_do_ano) - int(mes_inicio_contrato) + 1
+            avos_13 = int(payslip.mes_do_ano2) - int(mes_inicio_contrato) + 1
 
             adiantamento_avos_13 = 13 - int(mes_inicio_contrato)
 
@@ -1799,11 +1799,11 @@ class HrPayslip(models.Model):
                 avos_13 -= 1
                 adiantamento_avos_13 -= 1
         else:
-            avos_13 = payslip.mes_do_ano
+            avos_13 = payslip.mes_do_ano2
 
         if payslip.contract_id.date_end:
             if datetime.strptime(payslip.contract_id.date_end, '%Y-%m-%d').month \
-                    == payslip.mes_do_ano:
+                    == payslip.mes_do_ano2:
                 dia_fim_contrato = \
                     fields.Date.from_string(payslip.contract_id.date_end).day
                 if dia_fim_contrato <= 15:


### PR DESCRIPTION
O sistema estava utilizando o campo "mes_do_ano", que no caso do holerite de 13º salário é computado como "13". O certo seria utilizar o campo "mes_do_ano2" que computa o mês correto deste holerite, que seria "12".