### PR TITLE
[FIX] Correção no calculo de dias entre periodos de alteração contratual

### DIFF
--- a/l10n_br_hr_payroll/models/hr_contract.py
+++ b/l10n_br_hr_payroll/models/hr_contract.py
@@ -110,6 +110,7 @@ class HrContract(models.Model):
                     datetime.strptime(change[i].change_date, "%Y-%m-%d")
                 d_inicio = datetime.strptime(data_inicio, "%Y-%m-%d")
                 d_fim = datetime.strptime(data_fim, "%Y-%m-%d")
+                d_fim = d_fim.replace(day=30)
 
                 dias = (d_fim - d_inicio) + timedelta(days=1)
 
@@ -126,8 +127,8 @@ class HrContract(models.Model):
                     # Calcula o número de dias dentro do período e quantos dias
                     # são de cada lado da alteração contratual
                     #
-                    dias_2 = dias.days - data_mudanca.day
-                    dias_1 = (data_mudanca.day - d_inicio.day) + 1
+                    dias_2 = (dias.days - data_mudanca.day) + 1
+                    dias_1 = data_mudanca.day - d_inicio.day
 
                     # Calcula cada valor de salário nos dias em com valores
                     # diferentes


### PR DESCRIPTION
Para cálculos salariais o sistema deve considerar sempre o dia 30 como data_fim, isso serve para evitar erro em meses em que há 31 dias ou 28 dias.

A data da mudança (promoção ou alteração) deve ser considerada para o 2º período de salário e não para o 1º.

Exemplo:

Data da mudança = 16/01/2018

O dia 16 deverá ser considerado para o 2º período, somando a seguinte quantidade:

1º período = 15 dias (16 - 1)
2º período = 15 dias ( (30 - 16) + 1 ), o "+1" serve para que o próprio dia 16 seja considerado.